### PR TITLE
Neo Brutalism portfolio revamp + mobile optimization

### DIFF
--- a/src/components/portfolio/About.jsx
+++ b/src/components/portfolio/About.jsx
@@ -14,16 +14,16 @@ const CERTS = [
 
 export default function About() {
   return (
-    <section id="about" className="py-24 bg-cream border-b-2 border-ink">
+    <section id="about" className="py-16 md:py-24 bg-cream border-b-2 border-ink">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="mb-14">
+        <div className="mb-8 md:mb-14">
           <span className="section-label">001 — About</span>
         </div>
 
-        <div className="grid lg:grid-cols-[1fr_400px] gap-16 items-start">
+        <div className="grid lg:grid-cols-[1fr_400px] gap-10 lg:gap-16 items-start">
           {/* Left: bio */}
           <div>
-            <h2 className="section-heading text-5xl md:text-6xl lg:text-7xl mb-10">
+            <h2 className="section-heading text-4xl sm:text-5xl md:text-6xl lg:text-7xl mb-7 md:mb-10">
               WHO
               <br />
               <span className="relative inline-block">
@@ -54,7 +54,7 @@ export default function About() {
             </div>
 
             {/* Contact links */}
-            <div className="mt-10 flex flex-wrap gap-3">
+            <div className="mt-7 md:mt-10 flex flex-wrap gap-3">
               <a href="mailto:shubham8186@gmail.com" className="btn-brutal !text-xs !py-2">
                 shubham8186@gmail.com
               </a>
@@ -69,7 +69,7 @@ export default function About() {
             </div>
 
             {/* Certs */}
-            <div className="mt-10 pt-8 border-t-2 border-ink">
+            <div className="mt-7 md:mt-10 pt-6 md:pt-8 border-t-2 border-ink">
               <p className="font-mono text-xs uppercase tracking-widest text-ink/40 mb-4">
                 Certifications & Recognition
               </p>

--- a/src/components/portfolio/Contact.jsx
+++ b/src/components/portfolio/Contact.jsx
@@ -61,16 +61,16 @@ export default function Contact() {
   }
 
   return (
-    <section id="contact" className="py-24 bg-cream border-b-2 border-ink">
+    <section id="contact" className="py-16 md:py-24 bg-cream border-b-2 border-ink">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="mb-14">
+        <div className="mb-8 md:mb-14">
           <span className="section-label">006 — Contact</span>
         </div>
 
-        <div className="grid lg:grid-cols-2 gap-16 items-start">
+        <div className="grid lg:grid-cols-2 gap-10 lg:gap-16 items-start">
           {/* LEFT */}
           <div>
-            <h2 className="section-heading text-5xl md:text-6xl lg:text-7xl mb-8">
+            <h2 className="section-heading text-4xl sm:text-5xl md:text-6xl lg:text-7xl mb-6 md:mb-8">
               LET'S
               <br />
               <span className="relative inline-block">
@@ -125,7 +125,7 @@ export default function Contact() {
 
           {/* RIGHT — Form */}
           <div className="border-2 border-ink shadow-brutal-xl bg-cream">
-            <div className="border-b-2 border-ink px-8 py-5 bg-yellow flex items-center justify-between">
+            <div className="border-b-2 border-ink px-5 sm:px-8 py-4 sm:py-5 bg-yellow flex items-center justify-between">
               <h3 className="font-syne font-black text-lg uppercase tracking-tight">
                 Send a Message
               </h3>
@@ -136,8 +136,8 @@ export default function Contact() {
               )}
             </div>
 
-            <form ref={formRef} onSubmit={handleSubmit} className="p-8 space-y-5">
-              <div className="grid sm:grid-cols-2 gap-4">
+            <form ref={formRef} onSubmit={handleSubmit} className="p-5 sm:p-8 space-y-4 sm:space-y-5">
+              <div className="grid grid-cols-1 xs:grid-cols-2 sm:grid-cols-2 gap-4">
                 <div>
                   <label className="font-mono text-[10px] uppercase tracking-widest text-ink/50 block mb-1.5">
                     Name *

--- a/src/components/portfolio/Experience.jsx
+++ b/src/components/portfolio/Experience.jsx
@@ -77,13 +77,13 @@ const EXPERIENCES = [
 
 export default function Experience() {
   return (
-    <section id="experience" className="py-24 bg-cream border-b-2 border-ink">
+    <section id="experience" className="py-16 md:py-24 bg-cream border-b-2 border-ink">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="mb-14">
+        <div className="mb-8 md:mb-14">
           <span className="section-label">003 — Experience</span>
         </div>
 
-        <h2 className="section-heading text-5xl md:text-6xl lg:text-7xl mb-16">
+        <h2 className="section-heading text-4xl sm:text-5xl md:text-6xl lg:text-7xl mb-10 md:mb-16">
           WHERE I'VE
           <br />
           <span className="relative inline-block">
@@ -99,30 +99,32 @@ export default function Experience() {
               className="border-2 border-ink shadow-brutal-xl overflow-hidden card-hover"
             >
               {/* Card header */}
-              <div className={`${exp.headerBg} border-b-2 border-ink p-6 flex flex-wrap items-start justify-between gap-4`}>
-                <div>
-                  <div className="flex items-center gap-3 mb-2 flex-wrap">
-                    <h3 className="font-syne font-black text-2xl md:text-3xl text-ink uppercase tracking-tight">
-                      {exp.company}
-                    </h3>
-                    <span
-                      className={`${exp.badgeBg} font-mono text-[10px] border-2 border-ink text-ink px-2 py-0.5 uppercase tracking-widest`}
-                    >
-                      {exp.badge}
-                    </span>
+              <div className={`${exp.headerBg} border-b-2 border-ink p-4 md:p-6`}>
+                <div className="flex flex-wrap items-start justify-between gap-2 md:gap-4">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 md:gap-3 mb-1.5 flex-wrap">
+                      <h3 className="font-syne font-black text-xl sm:text-2xl md:text-3xl text-ink uppercase tracking-tight">
+                        {exp.company}
+                      </h3>
+                      <span
+                        className={`${exp.badgeBg} font-mono text-[10px] border-2 border-ink text-ink px-2 py-0.5 uppercase tracking-widest shrink-0`}
+                      >
+                        {exp.badge}
+                      </span>
+                    </div>
+                    <p className="font-grotesk font-semibold text-ink/80 text-sm">{exp.role}</p>
+                    <p className="font-mono text-[11px] text-ink/50 mt-0.5">{exp.companyFull}</p>
                   </div>
-                  <p className="font-grotesk font-semibold text-ink/80 text-sm">{exp.role}</p>
-                  <p className="font-mono text-[11px] text-ink/50 mt-0.5">{exp.companyFull}</p>
-                </div>
-                <div className="text-right">
-                  <p className="font-mono text-sm font-bold text-ink">{exp.period}</p>
-                  <p className="font-mono text-xs text-ink/60 mt-1">{exp.location}</p>
+                  <div className="text-right shrink-0">
+                    <p className="font-mono text-xs sm:text-sm font-bold text-ink">{exp.period}</p>
+                    <p className="font-mono text-[11px] text-ink/60 mt-1">{exp.location}</p>
+                  </div>
                 </div>
               </div>
 
               {/* Card body */}
-              <div className="bg-cream p-6">
-                <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-6">
+              <div className="bg-cream p-4 md:p-6">
+                <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-3 md:gap-4 mb-4 md:mb-6">
                   {exp.highlights.map((h, j) => (
                     <div key={j} className="border border-ink/20 p-3 hover:border-ink transition-colors duration-150">
                       <p className="font-grotesk font-bold text-xs text-ink uppercase tracking-wide mb-1.5 flex items-center gap-2">
@@ -133,7 +135,7 @@ export default function Experience() {
                     </div>
                   ))}
                 </div>
-                <div className="pt-4 border-t border-ink/10 flex flex-wrap gap-2">
+                <div className="pt-3 md:pt-4 border-t border-ink/10 flex flex-wrap gap-2">
                   {exp.tags.map((tag) => (
                     <span key={tag} className="skill-tag !text-[10px] !py-1">
                       {tag}

--- a/src/components/portfolio/Footer.jsx
+++ b/src/components/portfolio/Footer.jsx
@@ -20,10 +20,10 @@ export default function Footer() {
     <footer className="bg-ink text-cream border-t-2 border-ink">
       {/* Top strip */}
       <div className="border-b border-cream/10">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-          <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-10">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10 md:py-12">
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-8 md:gap-10">
             {/* Brand */}
-            <div className="lg:col-span-2">
+            <div className="col-span-2 lg:col-span-2">
               <div className="flex items-center gap-3 mb-5">
                 <div className="w-12 h-12 bg-yellow border-2 border-cream flex items-center justify-center shadow-brutal-yellow">
                   <span className="font-syne font-black text-ink text-xl">SS</span>

--- a/src/components/portfolio/Hero.jsx
+++ b/src/components/portfolio/Hero.jsx
@@ -25,13 +25,13 @@ export default function Hero() {
       <div className="absolute bottom-40 left-6 w-12 h-12 bg-blue border-2 border-ink shadow-brutal hidden xl:block" />
       <div className="absolute bottom-60 left-24 w-6 h-6 bg-green border-2 border-ink hidden xl:block" />
 
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-12 pb-4">
-        <div className="grid lg:grid-cols-2 gap-12 lg:gap-8 items-center min-h-[calc(100vh-8rem)]">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-8 sm:pt-12 pb-4">
+        <div className="grid lg:grid-cols-2 gap-8 lg:gap-8 items-center">
 
           {/* LEFT — Text content */}
-          <div className="relative z-10 order-2 lg:order-1">
+          <div className="relative z-10 order-1">
             {/* Status badge */}
-            <div className="mb-7 flex items-center gap-3 flex-wrap">
+            <div className="mb-5 sm:mb-7 flex items-center gap-3 flex-wrap">
               <span className="section-label flex items-center gap-2">
                 <span className="w-2 h-2 bg-green rounded-full animate-pulse" />
                 SDE @ NOISE · Gurugram
@@ -39,54 +39,56 @@ export default function Hero() {
             </div>
 
             {/* Name */}
-            <h1 className="section-heading text-[clamp(3.5rem,9vw,6.5rem)] mb-1 leading-[0.92]">
+            <h1 className="section-heading text-[clamp(3rem,9vw,6.5rem)] mb-1 leading-[0.92]">
               SHUBHAM
             </h1>
-            <div className="relative inline-block mb-5">
-              <h1 className="section-heading text-[clamp(3.5rem,9vw,6.5rem)] relative z-10 px-2 leading-[0.92]">
+            <div className="relative inline-block mb-4">
+              <h1 className="section-heading text-[clamp(3rem,9vw,6.5rem)] relative z-10 px-2 leading-[0.92]">
                 SHARMA
               </h1>
               <div className="absolute inset-y-0 left-0 right-0 bg-yellow border-b-4 border-ink -z-0 -skew-x-1 top-1" />
             </div>
 
-            <p className="font-mono text-xs uppercase tracking-[0.25em] text-ink/50 mb-8">
+            <p className="font-mono text-[10px] sm:text-xs uppercase tracking-[0.2em] sm:tracking-[0.25em] text-ink/50 mb-6 sm:mb-8">
               Full-Stack ✦ AI/ML ✦ Agentic Systems
             </p>
 
             {/* Bio */}
-            <p className="font-grotesk text-base text-ink/75 max-w-[480px] mb-10 leading-relaxed">
+            <p className="font-grotesk text-sm sm:text-base text-ink/75 max-w-[480px] mb-8 sm:mb-10 leading-relaxed">
               Building production-grade systems at{' '}
               <strong className="text-ink">NOISE</strong> — agentic AI workflows,
               real-time auction platforms, and e-commerce serving millions.
             </p>
 
             {/* CTAs */}
-            <div className="flex flex-wrap gap-3 mb-12">
-              <a href="#projects" className="btn-brutal">
+            <div className="flex flex-wrap gap-2 sm:gap-3 mb-8 sm:mb-12">
+              <a href="#projects" className="btn-brutal !px-4 sm:!px-6 !text-xs">
                 View Work ↓
               </a>
-              <a href="#contact" className="btn-brutal-outline">
+              <a href="#contact" className="btn-brutal-outline !px-4 sm:!px-6 !text-xs">
                 Contact Me →
               </a>
               <a
                 href="https://github.com/shubhamsharma2003"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="btn-brutal-dark"
+                className="btn-brutal-dark !px-4 sm:!px-6 !text-xs"
               >
                 GitHub ↗
               </a>
             </div>
 
-            {/* Stats row */}
-            <div className="flex flex-wrap gap-0 border-2 border-ink w-fit shadow-brutal">
+            {/* Stats row — 2×2 on mobile, 1×4 on sm+ */}
+            <div className="grid grid-cols-2 sm:grid-cols-4 border-2 border-ink shadow-brutal w-full sm:w-fit max-w-xs sm:max-w-none">
               {STATS.map((s, i) => (
                 <div
                   key={s.label}
-                  className={`px-5 py-3 text-center ${i < STATS.length - 1 ? 'border-r-2 border-ink' : ''}`}
+                  className={`px-3 sm:px-5 py-3 text-center ${
+                    i % 2 === 0 ? 'border-r-2 border-ink' : ''
+                  } ${i < 2 ? 'border-b-2 sm:border-b-0 border-ink' : ''}`}
                 >
-                  <div className="font-syne font-black text-xl text-ink">{s.num}</div>
-                  <div className="font-mono text-[10px] text-ink/50 uppercase tracking-wider mt-0.5">
+                  <div className="font-syne font-black text-lg sm:text-xl text-ink">{s.num}</div>
+                  <div className="font-mono text-[9px] sm:text-[10px] text-ink/50 uppercase tracking-wider mt-0.5">
                     {s.label}
                   </div>
                 </div>
@@ -95,30 +97,32 @@ export default function Hero() {
           </div>
 
           {/* RIGHT — Profile photo */}
-          <div className="relative flex justify-center lg:justify-end order-1 lg:order-2 pt-8 lg:pt-0">
-            <div className="relative w-56 h-64 sm:w-72 sm:h-80 lg:w-80 lg:h-[420px]">
-              {/* Layered offset frames */}
-              <div className="absolute inset-0 translate-x-5 translate-y-5 bg-pink border-2 border-ink" />
-              <div className="absolute inset-0 translate-x-3 translate-y-3 bg-yellow border-2 border-ink" />
-              {/* Photo container */}
-              <div className="absolute inset-0 border-2 border-ink overflow-hidden bg-ink z-10 group">
-                <img
-                  src={profilePic}
-                  alt="Shubham Sharma"
-                  className="w-full h-full object-cover object-top grayscale group-hover:grayscale-0 transition-all duration-700 scale-105 group-hover:scale-100"
-                />
-                {/* Overlay tint */}
-                <div className="absolute inset-0 bg-yellow/10 group-hover:bg-transparent transition-all duration-700" />
-              </div>
+          <div className="relative flex justify-center lg:justify-end order-2 mt-10 sm:mt-12 lg:mt-0">
+            {/* Extra padding to contain offset layers + floating labels */}
+            <div className="relative pt-6 pb-8 px-6 sm:pt-6 sm:pb-8 sm:px-8">
+              <div className="relative w-48 h-56 sm:w-64 sm:h-72 lg:w-80 lg:h-[420px]">
+                {/* Layered offset frames */}
+                <div className="absolute inset-0 translate-x-4 translate-y-4 sm:translate-x-5 sm:translate-y-5 bg-pink border-2 border-ink" />
+                <div className="absolute inset-0 translate-x-2 translate-y-2 sm:translate-x-3 sm:translate-y-3 bg-yellow border-2 border-ink" />
+                {/* Photo container */}
+                <div className="absolute inset-0 border-2 border-ink overflow-hidden bg-ink z-10 group">
+                  <img
+                    src={profilePic}
+                    alt="Shubham Sharma"
+                    className="w-full h-full object-cover object-top grayscale group-hover:grayscale-0 transition-all duration-700 scale-105 group-hover:scale-100"
+                  />
+                  <div className="absolute inset-0 bg-yellow/10 group-hover:bg-transparent transition-all duration-700" />
+                </div>
 
-              {/* Floating label */}
-              <div className="absolute -bottom-4 -left-4 z-20 bg-ink text-cream border-2 border-ink px-3 py-2 font-mono text-[10px] uppercase tracking-widest shadow-brutal-yellow">
-                Open to Opportunities
-              </div>
+                {/* Floating label — bottom left */}
+                <div className="absolute -bottom-5 -left-5 sm:-bottom-4 sm:-left-4 z-20 bg-ink text-cream border-2 border-ink px-2 sm:px-3 py-1.5 sm:py-2 font-mono text-[9px] sm:text-[10px] uppercase tracking-wider sm:tracking-widest shadow-brutal-yellow whitespace-nowrap">
+                  Open to Opportunities
+                </div>
 
-              {/* Role tag */}
-              <div className="absolute -top-4 -right-4 z-20 bg-green border-2 border-ink px-3 py-2 font-mono text-[10px] uppercase tracking-widest shadow-brutal">
-                SDE1
+                {/* Role tag — top right */}
+                <div className="absolute -top-4 -right-4 z-20 bg-green border-2 border-ink px-2 sm:px-3 py-1.5 sm:py-2 font-mono text-[9px] sm:text-[10px] uppercase tracking-wider sm:tracking-widest shadow-brutal">
+                  SDE1
+                </div>
               </div>
             </div>
           </div>

--- a/src/components/portfolio/Projects.jsx
+++ b/src/components/portfolio/Projects.jsx
@@ -84,14 +84,14 @@ const PROJECTS = [
 
 export default function Projects() {
   return (
-    <section id="projects" className="py-24 bg-cream border-b-2 border-ink">
+    <section id="projects" className="py-16 md:py-24 bg-cream border-b-2 border-ink">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="mb-14">
+        <div className="mb-8 md:mb-14">
           <span className="section-label">004 — Projects</span>
         </div>
 
-        <div className="grid lg:grid-cols-2 gap-4 items-start mb-12">
-          <h2 className="section-heading text-5xl md:text-6xl lg:text-7xl">
+        <div className="grid lg:grid-cols-2 gap-4 items-start mb-8 md:mb-12">
+          <h2 className="section-heading text-4xl sm:text-5xl md:text-6xl lg:text-7xl">
             SELECTED
             <br />
             <span className="relative inline-block">
@@ -99,7 +99,7 @@ export default function Projects() {
               <span className="absolute left-0 right-0 bottom-0 h-4 bg-blue -z-10" />
             </span>
           </h2>
-          <div className="flex items-end">
+          <div className="hidden sm:flex items-end">
             <p className="font-mono text-xs text-ink/40 uppercase tracking-widest leading-relaxed">
               From AI/ML research to freelance production work.
               <br />
@@ -111,22 +111,22 @@ export default function Projects() {
         {/* First project — wide featured card */}
         <div className="mb-4">
           <div className="border-2 border-ink shadow-brutal-xl card-hover flex flex-col sm:flex-row overflow-hidden group">
-            <div className={`${PROJECTS[0].accent} border-r-2 border-ink p-8 sm:w-16 flex sm:flex-col items-center justify-between sm:justify-start gap-4`}>
-              <span className="font-syne font-black text-4xl text-ink/20 rotate-0 sm:-rotate-90 sm:writing-mode-vertical">
+            <div className={`${PROJECTS[0].accent} border-b-2 sm:border-b-0 sm:border-r-2 border-ink p-4 sm:p-8 sm:w-16 flex sm:flex-col items-center justify-between sm:justify-start gap-4`}>
+              <span className="font-syne font-black text-4xl text-ink/20">
                 {PROJECTS[0].num}
               </span>
               <span className="font-mono text-[10px] border-2 border-ink bg-ink text-cream px-2 py-0.5 uppercase tracking-wider whitespace-nowrap">
                 {PROJECTS[0].label}
               </span>
             </div>
-            <div className="flex-1 p-8">
-              <h3 className="font-syne font-black text-2xl md:text-3xl uppercase mb-4 leading-tight">
+            <div className="flex-1 p-5 sm:p-8">
+              <h3 className="font-syne font-black text-xl sm:text-2xl md:text-3xl uppercase mb-3 md:mb-4 leading-tight">
                 {PROJECTS[0].title}
               </h3>
-              <p className="font-grotesk text-sm text-ink/70 leading-relaxed mb-6 max-w-2xl">
+              <p className="font-grotesk text-sm text-ink/70 leading-relaxed mb-4 md:mb-6 max-w-2xl">
                 {PROJECTS[0].description}
               </p>
-              <div className="flex flex-wrap gap-2 mb-6">
+              <div className="flex flex-wrap gap-2 mb-4 md:mb-6">
                 {PROJECTS[0].tech.map((t) => (
                   <span key={t} className="skill-tag !text-[11px]">{t}</span>
                 ))}

--- a/src/components/portfolio/Publications.jsx
+++ b/src/components/portfolio/Publications.jsx
@@ -1,17 +1,17 @@
 export default function Publications() {
   return (
-    <section id="publications" className="py-24 bg-yellow border-y-2 border-ink">
+    <section id="publications" className="py-16 md:py-24 bg-yellow border-y-2 border-ink">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="mb-14">
+        <div className="mb-8 md:mb-14">
           <span className="font-mono text-xs uppercase tracking-[0.3em] border-2 border-ink bg-ink text-cream px-3 py-1 inline-block">
             005 — Publications
           </span>
         </div>
 
-        <div className="grid lg:grid-cols-2 gap-12 lg:gap-20 items-center">
+        <div className="grid lg:grid-cols-2 gap-8 lg:gap-20 items-center">
           {/* Left */}
           <div>
-            <h2 className="section-heading text-5xl md:text-6xl lg:text-7xl text-ink mb-6">
+            <h2 className="section-heading text-4xl sm:text-5xl md:text-6xl lg:text-7xl text-ink mb-5 md:mb-6">
               RESEARCH
               <br />
               PUBLISHED
@@ -34,7 +34,7 @@ export default function Publications() {
           </div>
 
           {/* Right — Paper card */}
-          <div className="border-2 border-ink bg-cream shadow-brutal-xl p-8">
+          <div className="border-2 border-ink bg-cream shadow-brutal-xl p-5 sm:p-8">
             <div className="flex items-start gap-4 mb-6">
               <span className="font-syne font-black text-6xl text-ink/10 leading-none select-none">¶</span>
               <div>

--- a/src/components/portfolio/Skills.jsx
+++ b/src/components/portfolio/Skills.jsx
@@ -27,16 +27,16 @@ const SKILL_GROUPS = [
 
 export default function Skills() {
   return (
-    <section id="skills" className="py-24 bg-ink text-cream border-b-2 border-ink">
+    <section id="skills" className="py-16 md:py-24 bg-ink text-cream border-b-2 border-ink">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="mb-14">
+        <div className="mb-8 md:mb-14">
           <span className="font-mono text-xs uppercase tracking-[0.3em] border-2 border-cream bg-cream text-ink px-3 py-1 inline-block">
             002 — Skills
           </span>
         </div>
 
-        <div className="grid lg:grid-cols-[1fr_auto] gap-12 items-start mb-16">
-          <h2 className="section-heading text-5xl md:text-6xl lg:text-7xl text-cream">
+        <div className="grid lg:grid-cols-[1fr_auto] gap-6 md:gap-12 items-start mb-10 md:mb-16">
+          <h2 className="section-heading text-4xl sm:text-5xl md:text-6xl lg:text-7xl text-cream">
             TECH
             <br />
             <span className="text-yellow">ARSENAL</span>
@@ -50,17 +50,17 @@ export default function Skills() {
           </div>
         </div>
 
-        <div className="space-y-10">
+        <div className="space-y-8 md:space-y-10">
           {SKILL_GROUPS.map((group) => (
             <div key={group.category}>
-              <div className="flex items-center gap-4 mb-5">
+              <div className="flex items-center gap-4 mb-4 md:mb-5">
                 <span className={`font-mono text-xs uppercase tracking-[0.25em] ${group.color} font-bold`}>
                   {group.category}
                 </span>
                 <div className="flex-1 h-px bg-cream/10" />
                 <span className="font-mono text-xs text-cream/20">{group.items.length}</span>
               </div>
-              <div className="flex flex-wrap gap-2.5">
+              <div className="flex flex-wrap gap-2">
                 {group.items.map((skill) => (
                   <span
                     key={skill}


### PR DESCRIPTION
## What's in this PR

Complete redesign of the portfolio from the VS Code theme to a **Neo Brutalism** one-pager, plus full mobile optimization pass.

### Design system
- Cream `#FFFEF0` background, Ink `#0A0A0A` borders, Yellow `#FFE500` primary accent, Pink, Electric Blue, Neon Green
- Fonts: Syne (headings), Space Grotesk (body), Space Mono (labels/code)
- Hard offset box shadows, thick 2px black borders, hover "press" animations

### New sections (one-pager, no routing)
- **Hero** — animated ticker, layered profile frame, 4-stat bar
- **About** — bio + colored stat cards + education card
- **Skills** — dark section, 4 categorized groups with hover-colored tags
- **Experience** — NOISE SDE1 + Intern cards with highlight grids
- **Projects** — featured wide card + 5-card grid with grayscale-to-color hover
- **Publications** — IEEE ICCoSD 2025 paper (DOI linked)
- **Contact** — EmailJS form with success/error state + social links
- **Footer** — dark 4-column layout

### Content updated from resume
- SDE1 @ NOISE (Aug 2025–Present) with 7 project highlights
- Full-Stack Intern @ NOISE (Feb–Jul 2025) with 5 highlights
- Unisel Realty freelance project (Next.js + Sanity CMS)
- ML projects: Multilingual Language Recognition (98% acc), Land Cover Segmentation (U-Net)
- IEEE publication linked

### Mobile fixes
- Hero: text-first ordering, no forced min-height, 2×2 stats grid on mobile
- All sections: `py-24 → py-16 md:py-24`, headings `text-4xl sm:text-5xl`
- Experience cards: reduced padding, non-squishing header layout
- Projects: featured card accent bar switches to horizontal on mobile
- Contact: form stacks on mobile, padding reduced
- Footer: 2-column grid on mobile

---
_Generated by [Claude Code](https://claude.ai/code/session_01CjFwUvtivHD55hsTN4UCnH)_