### PR TITLE
Fix hero name overflow on mobile — drop clamp floor from 3rem to 1.5rem

### DIFF
--- a/src/components/portfolio/Hero.jsx
+++ b/src/components/portfolio/Hero.jsx
@@ -39,11 +39,11 @@ export default function Hero() {
             </div>
 
             {/* Name */}
-            <h1 className="section-heading text-[clamp(3rem,9vw,6.5rem)] mb-1 leading-[0.92]">
+            <h1 className="section-heading text-[clamp(1.5rem,8.5vw,6.5rem)] mb-1 leading-[0.92]">
               SHUBHAM
             </h1>
             <div className="relative inline-block mb-4">
-              <h1 className="section-heading text-[clamp(3rem,9vw,6.5rem)] relative z-10 px-2 leading-[0.92]">
+              <h1 className="section-heading text-[clamp(1.5rem,8.5vw,6.5rem)] relative z-10 px-2 leading-[0.92]">
                 SHARMA
               </h1>
               <div className="absolute inset-y-0 left-0 right-0 bg-yellow border-b-4 border-ink -z-0 -skew-x-1 top-1" />


### PR DESCRIPTION
clamp(3rem,9vw,6.5rem) forced 48px+ on all screens < 530px wide causing SHUBHAM to overflow. New clamp(1.5rem,8.5vw,6.5rem) lets vw drive the size on mobile (390px → ~33px, fits well within content area).

https://claude.ai/code/session_01CjFwUvtivHD55hsTN4UCnH